### PR TITLE
Add pillow dependency, use ffmpeg as fallback

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ except:
 	print("Unable to import Raspberry Pi wheels due to exception, building the slow way.")
 
 if add_pillow:
-	plugin_requires = ["Pillow"] + plugin_requires
+	plugin_requires = ["Pillow>=9.0.0,<12.0.0"] + plugin_requires
 
 setup_parameters = octoprint_setuptools.create_plugin_setup_parameters(
 	identifier=plugin_identifier,


### PR DESCRIPTION
- Adds Pillow as an explicit dependency (>=9.0.0,<12.0.0) for image processing
- Adds ffmpeg as a fallback for snapshot compression when Pillow is unavailable or fails to install
- Reduces photo quality for both PIL and ffmpeg paths to reliably get images under max_image_size
- Gracefully degrades when neither PIL nor ffmpeg is available